### PR TITLE
Remove gender

### DIFF
--- a/force-app/main/default/objects/SYS_OrgLimitSnapshot__c/SYS_OrgLimitSnapshot__c.object-meta.xml
+++ b/force-app/main/default/objects/SYS_OrgLimitSnapshot__c/SYS_OrgLimitSnapshot__c.object-meta.xml
@@ -154,7 +154,6 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <externalSharingModel>Private</externalSharingModel>
-    <gender>Masculine</gender>
     <label>SYS OrgLimitSnapshot</label>
     <nameField>
         <label>Limit Name</label>

--- a/force-app/main/default/objects/SYS_OrgStorageSnapshot__c/SYS_OrgStorageSnapshot__c.object-meta.xml
+++ b/force-app/main/default/objects/SYS_OrgStorageSnapshot__c/SYS_OrgStorageSnapshot__c.object-meta.xml
@@ -154,7 +154,6 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <externalSharingModel>Private</externalSharingModel>
-    <gender>Feminine</gender>
     <label>SYS OrgStorage Snapshot</label>
     <nameField>
         <label>Item Name</label>

--- a/force-app/main/default/objects/SYS_PicklistSnapshot__c/SYS_PicklistSnapshot__c.object-meta.xml
+++ b/force-app/main/default/objects/SYS_PicklistSnapshot__c/SYS_PicklistSnapshot__c.object-meta.xml
@@ -154,7 +154,6 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <externalSharingModel>Private</externalSharingModel>
-    <gender>Masculine</gender>
     <label>SYS Picklist Snapshot</label>
     <nameField>
         <label>Value Name</label>

--- a/force-app/main/default/tabs/SYS_OrgLimitSnapshot__c.tab-meta.xml
+++ b/force-app/main/default/tabs/SYS_OrgLimitSnapshot__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom67: Gears</motif>
+</CustomTab>

--- a/force-app/main/default/tabs/SYS_OrgStorageSnapshot__c.tab-meta.xml
+++ b/force-app/main/default/tabs/SYS_OrgStorageSnapshot__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom87: Safe</motif>
+</CustomTab>

--- a/force-app/main/default/tabs/SYS_PicklistSnapshot__c.tab-meta.xml
+++ b/force-app/main/default/tabs/SYS_PicklistSnapshot__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom55: Books</motif>
+</CustomTab>


### PR DESCRIPTION
Hi @pegros ,
I had problems deploying PEG_SYS to my trial org and it was because it was missing the custom tabs and the Custom Objects included gender settings... (see https://help.salesforce.com/s/articleView?id=000386103&type=1)

Gender is not available in all locale's hence have removed it's attributes from the object definition.